### PR TITLE
chore: add AGENTS.md and update Copilot instructions for AI assistants

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,16 @@
+# Copilot Workspace Instructions
+
+Read `/AGENTS.md` before generating or editing code.
+
+## Source of truth
+
+- Primary architecture and coding rules: `/AGENTS.md`
+- Team workflow copy of Copilot instructions: `/.github/workflows/copilot-instructions.md`
+
+## Mandatory rules
+
+- Follow Feature-Sliced Design layers and dependency direction.
+- Use TypeScript strong typing (avoid `any`).
+- Keep business logic out of purely presentational UI.
+- Reuse existing modules and avoid unnecessary files.
+- Follow project naming and security conventions from `/AGENTS.md`.

--- a/.github/workflows/copilot-instructions.md
+++ b/.github/workflows/copilot-instructions.md
@@ -1,0 +1,53 @@
+# Copilot Instructions
+
+Mandatory instruction for GitHub Copilot and AI coding assistants in this repository.
+
+## Required First Step
+
+Before generating or editing code, ALWAYS read and follow `/AGENTS.md`.
+
+If there is any doubt or conflict, `/AGENTS.md` is the source of truth.
+
+## Core Rules Summary
+
+- Follow Feature-Sliced Design layers: `shared`, `entities`, `features`, `widgets`, `pages`.
+- Respect dependency direction: `pages -> widgets -> features -> entities -> shared`.
+- Keep routes in `src/app`, but organize domain code in FSD layers under `src/`.
+- Do not mix business logic with presentational UI.
+- Use TypeScript strong typing and avoid `any`.
+- Reuse existing code and avoid unnecessary files.
+- Follow naming conventions: components in PascalCase, functions in camelCase, hooks with `use` prefix.
+- Apply security basics: no hardcoded secrets, no sensitive data exposure, validate inputs.
+
+## Expected Behavior for Copilot
+
+When asked to create a new feature, Copilot should:
+
+1. Check existing modules to reuse code.
+2. Propose the feature under `src/features/<feature-name>`.
+3. Keep UI and logic separated.
+4. Create explicit types/interfaces.
+5. Keep imports compliant with FSD direction.
+6. Return only necessary files/changes.
+
+## Practical Validation Prompt
+
+Use this prompt in Copilot Chat to validate instruction adherence:
+
+```text
+Create a new "newsletter-subscription" feature using this repository standards.
+Requirements:
+- Use FSD structure.
+- Separate UI and business logic.
+- Use strict TypeScript types (no any).
+- Reuse existing entities when possible.
+- Keep Next.js route composition in src/app.
+```
+
+Validation checklist:
+
+- Output files are inside expected FSD layers.
+- No business rules inside purely presentational component.
+- No `any` types.
+- Naming conventions are respected.
+- No unnecessary files were created.

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,7 @@
 {
   "recommendations": [
     "esbenp.prettier-vscode",
-    "dbaeumer.vscode-eslint"
+    "dbaeumer.vscode-eslint",
+    "openai.chatgpt"
   ]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,123 @@
+# AGENTS.md
+
+This document is the source of truth for AI assistants (including GitHub Copilot) in this repository.
+All generated code MUST follow these rules.
+
+## 1. Scope and Priority
+
+- Scope: entire repository.
+- Priority: when there is any conflict, this file has precedence for architecture and coding decisions.
+- Copilot integration: `.github/workflows/copilot-instructions.md` MUST reference and enforce this file.
+
+## 2. Project Stack
+
+- Next.js (App Router)
+- React
+- TypeScript
+- Tailwind CSS
+
+## 3. Architecture (Feature-Sliced Design)
+
+Use Feature-Sliced Design (FSD) for all new code.
+
+### 3.1 Layers
+
+- `shared`: reusable and generic code (UI kit, utilities, constants, low-level libs).
+- `entities`: business entities, domain types, entity-level UI/state/helpers.
+- `features`: user actions and business use cases.
+- `widgets`: composed UI blocks for pages.
+- `pages`: route-level composition and page assembly.
+
+### 3.2 Dependency Direction
+
+- Allowed direction: `pages -> widgets -> features -> entities -> shared`.
+- Lower layers MUST NOT depend on upper layers.
+- `shared` MUST NOT import from `entities/features/widgets/pages`.
+
+### 3.3 Next.js Mapping
+
+- Keep routes in `src/app` as required by Next.js.
+- Treat route files as the `pages` layer entrypoint and compose features/widgets there.
+- New domain code SHOULD live under `src/{shared,entities,features,widgets,pages}`.
+
+## 4. Folder and File Organization
+
+Target structure for new code:
+
+```text
+src/
+  app/                 # Next.js routing entrypoint
+  shared/
+    ui/
+    lib/
+    config/
+    types/
+  entities/
+  features/
+  widgets/
+  pages/
+```
+
+Rules:
+
+- UI primitives and reusable UI components MUST be in `src/shared/ui`.
+- Business logic for user-facing capabilities MUST be in `src/features`.
+- Entity models/types/domain behavior MUST be centralized in `src/entities`.
+- Do not create files/folders that are not used.
+- Prefer extending existing modules over creating duplicates.
+
+## 5. Coding Standards
+
+- Code, comments, identifiers, file/folder names MUST be in English.
+- Use strong typing with TypeScript. Avoid `any`.
+- Prefer small, composable, reusable functions/components.
+- Enforce separation of concerns: UI, business logic, data access.
+- Prefer composition over inheritance.
+- Avoid large components; split when responsibilities grow.
+- Do not duplicate logic; extract shared behavior.
+
+## 6. Naming Conventions
+
+- Files and folders: English names, kebab-case for files unless framework conventions require otherwise.
+- React components: PascalCase.
+- Functions and variables: camelCase.
+- Hooks: MUST start with `use`.
+- Types/interfaces/enums: PascalCase.
+
+## 7. Security Rules
+
+- Never expose secrets or sensitive data in frontend code.
+- Never hardcode secrets/tokens/credentials in source files.
+- Validate all external input (client and server boundaries).
+- Follow secure authentication and authorization practices.
+- Avoid logging sensitive data (tokens, passwords, personal data).
+
+## 8. Rules for New Features
+
+Every new feature MUST follow this checklist:
+
+- [ ] Create code inside `src/features/<feature-name>`.
+- [ ] Separate UI from business logic.
+- [ ] Create or reuse explicit TypeScript types/interfaces.
+- [ ] Reuse existing entities instead of redefining domain models.
+- [ ] Ensure complete typing (no implicit `any`).
+- [ ] Keep imports aligned with FSD dependency direction.
+- [ ] Add only necessary files.
+
+## 9. AI Assistant Operational Rules
+
+AI assistants (Copilot, chat agents, code generation tools) MUST:
+
+- Read `AGENTS.md` before proposing or generating code.
+- Follow FSD layers and dependency direction strictly.
+- Never place new code outside defined layers without explicit human instruction.
+- Never mix business logic and presentational UI in the same concern.
+- Always use TypeScript typing.
+- Prioritize reuse of existing code before creating new abstractions.
+- Keep output minimal, objective, and aligned with this repository conventions.
+
+## 10. Governance
+
+- This file MUST evolve with project architecture.
+- Keep rules practical and high-impact.
+- When rules become outdated, update this file first, then align generated code.


### PR DESCRIPTION
This pull request introduces a comprehensive set of instructions and architectural guidelines for AI coding assistants (such as GitHub Copilot) working in this repository. The main focus is to enforce Feature-Sliced Design (FSD), strong TypeScript typing, separation of concerns, and security standards, with `/AGENTS.md` as the authoritative source. The changes include new documentation files and explicit rules to ensure generated code adheres to project conventions.

Repository-wide AI assistant and architecture rules:

* Added `AGENTS.md` as the central source of truth for all AI-generated code, detailing FSD architecture, dependency direction, coding standards, naming conventions, and security rules.
* Introduced `.github/copilot-instructions.md` to instruct Copilot to read `/AGENTS.md` before generating or editing code, summarizing mandatory rules and workflow.
* Created `.github/workflows/copilot-instructions.md` with detailed instructions, practical prompts, and validation checklists for Copilot and other AI assistants, explicitly referencing `/AGENTS.md` as the primary authority.