### PR TITLE
[Route:/admin] Criar dashboard administrativo

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -3,7 +3,11 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   roots: ['<rootDir>/src'],
-  testMatch: ['**/*.spec.ts'],
+  testMatch: ['**/*.spec.ts', '**/*.spec.tsx'],
+  transform: {
+    // Sobrepõe o transform do preset: o tsconfig do Next usa jsx "preserve", que não roda em node
+    '^.+\\.tsx?$': ['ts-jest', { tsconfig: { jsx: 'react-jsx' } }],
+  },
   moduleNameMapper: {
     // Specific aliases first — more-specific patterns must precede the generic @/* catch-all
     '^next/server$': '<rootDir>/src/shared/test-utils/next-server.mock.ts',

--- a/src/app/(internal)/admin/members/new/page.tsx
+++ b/src/app/(internal)/admin/members/new/page.tsx
@@ -1,6 +1,9 @@
 import { AdminMemberForm } from '@/features/admin/members/ui/admin-member-form';
+import { requireAdminPageSession } from '@/shared/lib/page-auth';
 
-export default function NewMemberPage() {
+export default async function NewMemberPage() {
+  await requireAdminPageSession();
+
   return (
     <main>
       <AdminMemberForm />

--- a/src/app/(internal)/admin/members/page.tsx
+++ b/src/app/(internal)/admin/members/page.tsx
@@ -1,7 +1,7 @@
 // src/app/admin/members/page.tsx
-// TODO: restore auth check when login flow is ready
 import Link from 'next/link';
 import { prisma } from '@/shared/lib/prisma';
+import { requireAdminPageSession } from '@/shared/lib/page-auth';
 import { AdminMembersTable } from '@/features/admin/members/ui/admin-members-table';
 
 const VALID_LIMITS = [10, 20, 50] as const;
@@ -17,6 +17,8 @@ export default async function AdminMembersPage({
 }: {
   searchParams: Promise<{ page?: string; limit?: string }>;
 }) {
+  await requireAdminPageSession();
+
   const { page: pageParam, limit: limitParam } = await searchParams;
   const pageSize = parseLimit(limitParam);
   const page = Math.max(1, Number(pageParam ?? 1) || 1);

--- a/src/app/(internal)/admin/page.spec.tsx
+++ b/src/app/(internal)/admin/page.spec.tsx
@@ -1,0 +1,26 @@
+import AdminDashboardPage from './page';
+import { AdminDashboard } from '@/features/admin/dashboard/ui/admin-dashboard';
+import { requireAdminPageSession } from '@/shared/lib/page-auth';
+import { prisma } from '@/shared/lib/prisma';
+
+jest.mock('@/shared/lib/page-auth', () => ({ requireAdminPageSession: jest.fn() }));
+
+describe('AdminDashboardPage', () => {
+  beforeEach(() => {
+    (requireAdminPageSession as jest.Mock).mockResolvedValue({ user: { role: 'admin' } });
+    (prisma.post.count as jest.Mock).mockResolvedValue(5);
+    (prisma.member.count as jest.Mock).mockResolvedValue(3);
+    (prisma.project.count as jest.Mock).mockResolvedValue(2);
+  });
+
+  it('exige sessão administrativa antes de buscar métricas', async () => {
+    await AdminDashboardPage();
+    expect(requireAdminPageSession).toHaveBeenCalledTimes(1);
+  });
+
+  it('renderiza AdminDashboard com as três contagens', async () => {
+    const el = await AdminDashboardPage();
+    expect(el.type).toBe(AdminDashboard);
+    expect(el.props).toEqual({ posts: 5, members: 3, projects: 2 });
+  });
+});

--- a/src/app/(internal)/admin/page.tsx
+++ b/src/app/(internal)/admin/page.tsx
@@ -1,0 +1,15 @@
+import { prisma } from '@/shared/lib/prisma';
+import { requireAdminPageSession } from '@/shared/lib/page-auth';
+import { AdminDashboard } from '@/features/admin/dashboard/ui/admin-dashboard';
+
+export default async function AdminDashboardPage() {
+  await requireAdminPageSession();
+
+  const [posts, members, projects] = await Promise.all([
+    prisma.post.count(),
+    prisma.member.count(),
+    prisma.project.count(),
+  ]);
+
+  return <AdminDashboard posts={posts} members={members} projects={projects} />;
+}

--- a/src/features/admin/dashboard/ui/admin-dashboard.tsx
+++ b/src/features/admin/dashboard/ui/admin-dashboard.tsx
@@ -1,0 +1,41 @@
+import Link from 'next/link';
+import { AdminMetricCard } from './admin-metric-card';
+
+type Props = {
+  posts: number;
+  members: number;
+  projects: number;
+};
+
+export function AdminDashboard({ posts, members, projects }: Props) {
+  return (
+    <div className="architectural-grid min-h-screen bg-[#050505] px-6 py-16 text-white sm:px-10 lg:px-16">
+      <div className="mx-auto max-w-5xl">
+        <div className="mb-8">
+          <p className="text-xs font-semibold uppercase tracking-[0.28em] text-white/40">Admin</p>
+          <h1 className="mt-2 text-4xl font-black uppercase tracking-[-0.03em]">Dashboard</h1>
+        </div>
+
+        <div className="grid gap-4 sm:grid-cols-3">
+          <AdminMetricCard label="Posts" value={posts} delayClass="delay-100" />
+          <AdminMetricCard
+            label="Membros"
+            value={members}
+            href="/admin/members"
+            delayClass="delay-200"
+          />
+          <AdminMetricCard label="Projetos" value={projects} delayClass="delay-300" />
+        </div>
+
+        <div className="mt-8 animate-fade-up delay-400">
+          <Link
+            href="/admin/members/new"
+            className="inline-block rounded-full bg-white px-5 py-2.5 text-xs font-semibold uppercase tracking-[0.12em] text-black transition hover:bg-white/90"
+          >
+            Novo membro
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/admin/dashboard/ui/admin-metric-card.tsx
+++ b/src/features/admin/dashboard/ui/admin-metric-card.tsx
@@ -1,0 +1,35 @@
+import Link from 'next/link';
+
+type Props = {
+  label: string;
+  value: number;
+  /** Rota do CRUD. Sem href, o card exibe "Em breve" e não linka. */
+  href?: string;
+  delayClass?: string;
+};
+
+export function AdminMetricCard({ label, value, href, delayClass = '' }: Props) {
+  const baseClasses = `card-glow animate-fade-up ${delayClass} block rounded-2xl border border-white/10 bg-[#0e0e0e] p-6`;
+
+  const content = (
+    <>
+      <p className="text-xs font-semibold uppercase tracking-[0.28em] text-white/40">{label}</p>
+      <p className="mt-4 text-5xl font-black tracking-[-0.03em]">{value}</p>
+      {href ? (
+        <p className="mt-4 text-xs uppercase tracking-[0.14em] text-white/50">Gerenciar →</p>
+      ) : (
+        <p className="mt-4 text-xs uppercase tracking-[0.14em] text-white/30">Em breve</p>
+      )}
+    </>
+  );
+
+  if (href) {
+    return (
+      <Link href={href} className={`${baseClasses} transition hover:border-white/40`}>
+        {content}
+      </Link>
+    );
+  }
+
+  return <div className={baseClasses}>{content}</div>;
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,10 +1,8 @@
 import { getToken } from 'next-auth/jwt';
 import { NextRequest, NextResponse } from 'next/server';
-import type { UserRole } from '@prisma/client';
 import { LOCALE_COOKIE, defaultLocale, isLocale } from '@/shared/i18n/config';
 import { matchLocale } from '@/shared/i18n/match-locale';
-
-const ADMIN_ROLES = new Set<UserRole>(['admin', 'editor', 'member_manager']);
+import { ADMIN_ROLES } from '@/shared/lib/roles';
 
 const ONE_YEAR_SECONDS = 60 * 60 * 24 * 365;
 

--- a/src/shared/lib/api-helpers.ts
+++ b/src/shared/lib/api-helpers.ts
@@ -2,9 +2,7 @@ import { getServerSession } from 'next-auth';
 import { NextResponse } from 'next/server';
 import { authOptions } from '@/shared/lib/auth';
 import { reportServerError } from '@/shared/lib/discord';
-import type { UserRole } from '@prisma/client';
-
-const ADMIN_ROLES = new Set<UserRole>(['admin', 'editor', 'member_manager']);
+import { ADMIN_ROLES } from '@/shared/lib/roles';
 
 export async function requireAdminSession() {
   const session = await getServerSession(authOptions);

--- a/src/shared/lib/page-auth.spec.ts
+++ b/src/shared/lib/page-auth.spec.ts
@@ -1,0 +1,37 @@
+import { requireAdminPageSession } from './page-auth';
+import { getServerSession } from 'next-auth';
+import { redirect } from 'next/navigation';
+
+jest.mock('next-auth', () => ({ getServerSession: jest.fn() }));
+jest.mock('@/shared/lib/auth', () => ({ authOptions: {} }));
+jest.mock('next/navigation', () => ({
+  redirect: jest.fn((url: string) => {
+    // Emula o next real: redirect() lança e interrompe o fluxo.
+    throw new Error(`NEXT_REDIRECT:${url}`);
+  }),
+}));
+
+function sessionWithRole(role: string) {
+  return { user: { id: 'u1', name: 'User', email: 'u@test.com', role } };
+}
+
+describe('requireAdminPageSession', () => {
+  it('redireciona para /login quando não há sessão', async () => {
+    (getServerSession as jest.Mock).mockResolvedValue(null);
+    await expect(requireAdminPageSession()).rejects.toThrow('NEXT_REDIRECT:/login');
+    expect(redirect).toHaveBeenCalledWith('/login');
+  });
+
+  it('redireciona para / quando a role não é administrativa', async () => {
+    (getServerSession as jest.Mock).mockResolvedValue(sessionWithRole('member'));
+    await expect(requireAdminPageSession()).rejects.toThrow('NEXT_REDIRECT:/');
+    expect(redirect).toHaveBeenCalledWith('/');
+  });
+
+  it.each(['admin', 'editor', 'member_manager'])('retorna a sessão para role %s', async (role) => {
+    const session = sessionWithRole(role);
+    (getServerSession as jest.Mock).mockResolvedValue(session);
+    await expect(requireAdminPageSession()).resolves.toBe(session);
+    expect(redirect).not.toHaveBeenCalled();
+  });
+});

--- a/src/shared/lib/page-auth.ts
+++ b/src/shared/lib/page-auth.ts
@@ -1,0 +1,15 @@
+import { getServerSession } from 'next-auth';
+import { redirect } from 'next/navigation';
+import { authOptions } from '@/shared/lib/auth';
+import { ADMIN_ROLES } from '@/shared/lib/roles';
+
+/**
+ * Guard para páginas /admin (server components).
+ * Sem sessão → /login; role fora de ADMIN_ROLES → /.
+ */
+export async function requireAdminPageSession() {
+  const session = await getServerSession(authOptions);
+  if (!session) redirect('/login');
+  if (!ADMIN_ROLES.has(session.user.role)) redirect('/');
+  return session;
+}

--- a/src/shared/lib/roles.ts
+++ b/src/shared/lib/roles.ts
@@ -1,0 +1,4 @@
+import type { UserRole } from '@prisma/client';
+
+/** Roles com acesso à área administrativa (páginas /admin e APIs /api/admin). */
+export const ADMIN_ROLES = new Set<UserRole>(['admin', 'editor', 'member_manager']);


### PR DESCRIPTION
Closes #41

> [!IMPORTANT]
> **ORDEM DE MERGE: este é o primeiro dos três.** `#62` → `#63` (`/login`) → `#68` (editar membro).
> Os três foram rebaseados em `release` e o merge sequencial nessa ordem foi validado sem conflito.
> Este PR é independente: pode entrar sozinho.

## O que muda

- **`/admin` (SSR)**: dashboard com cards de métricas — contagem de posts, membros e projetos via `prisma.*.count()` (somente agregados, nenhum dado sensível chega ao cliente).
- **Proteção por sessão + role**: novo guard `requireAdminPageSession()` (`src/shared/lib/page-auth.ts`) — sem sessão redireciona para `/login`; role fora de `admin/editor/member_manager` redireciona para `/`. Roles extraídas para `src/shared/lib/roles.ts` como fonte única (APIs, páginas e proxy).
- **Guard aplicado às páginas admin existentes** (`/admin/members`, `/admin/members/new`), removendo o `TODO: restore auth check`.
- **Componentes** `AdminDashboard` e `AdminMetricCard` em `src/features/admin/dashboard/ui/`, seguindo o visual da área admin. Card Membros linka para o CRUD; Posts/Projetos exibem "Em breve" até as rotas existirem (#42, #48).
- **Jest**: suporte a `.spec.tsx` (transform `jsx: react-jsx`).

## Definition of Done

- [x] Rota protegida por autenticação — spec do guard + verificação manual (anônimo → 307 `/login`)
- [x] Rota protegida por role — spec do guard + verificação manual (`member` → 307 `/`)
- [x] Métricas exibidas sem dados sensíveis — página só recebe três `number`s

## Testes

- `page-auth.spec.ts`: redirect sem sessão, redirect com role `member`, passa com as 3 roles administrativas.
- `page.spec.tsx`: guard chamado antes das queries; props de `AdminDashboard` refletem os counts.
- Suíte completa nesta branch: **15 suites, 133 passando** (1 skipped). Lint, `format:check`, `tsc` e `next build` limpos.

---

## Rebase para `release` (atualizado)

A branch estava 19 commits atrás de `release`, que entretanto reestruturou o `src/app/`. Os 5 commits originais foram preservados; o que mudou no rebase:

- **Arquivos movidos para o route group `(internal)`**: `src/app/admin/page.tsx` e `page.spec.tsx` → `src/app/(internal)/admin/`. A `release` moveu o root layout (`<html>`, `globals.css`, fontes Geist, `AuthProvider`) para esse grupo; fora dele a página renderizaria sem CSS nenhum.
- **`src/proxy.ts` passou a importar `ADMIN_ROLES` de `roles.ts`.** A `release` introduziu uma terceira cópia do `Set` de roles no proxy novo; como este PR existe justamente para ter fonte única, a duplicata foi removida. Hoje os três consumidores (`proxy.ts`, `api-helpers.ts`, `page-auth.ts`) importam do mesmo módulo.
- **`api-helpers.ts`**: conflito resolvido mantendo o `reportServerError` que veio da `release` junto com o import novo de `ADMIN_ROLES`.

Todos os arquivos de feature ficaram **byte-idênticos** aos originais.

## Notas

- **Interação com o `proxy.ts` da `release`**: o proxy já protege `/admin` e, sozinho neste PR, ainda manda o anônimo para `/` (não para `/login`, que só passa a existir no #63). Como o proxy roda antes da página, o branch `sem sessão → /login` do guard só fica alcançável depois do #63. O guard permanece como defesa em profundidade e seu spec cobre os dois redirects.
- Encontrado no caminho (não tocado aqui, ainda válido): `npm run prisma:seed` está quebrado com Prisma 7 — `prisma.config.ts` não declara `migrations.seed` e o Prisma 7 ignora `package.json#prisma.seed`. O `prisma:seed:admin` adicionado na `release` contorna o caso do admin, mas o seed geral segue quebrado. Vale issue própria.
