### PR TITLE
docs: linkedin offensive security playbook

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,3 +43,15 @@ OCI_STORAGE_REGION="sa-saopaulo-1"
 OCI_STORAGE_BUCKET=""
 OCI_S3_ACCESS_KEY_ID=""
 OCI_S3_SECRET_ACCESS_KEY=""
+
+# --- LinkedIn (profile photo sync, issue #80) ---------------------------------
+# "Sign In with LinkedIn using OpenID Connect" app credentials. The redirect URI
+# registered on the LinkedIn app must be exactly:
+#   ${NEXT_PUBLIC_SITE_URL}/api/admin/members/linkedin/callback
+#
+# NEVER prefix these with NEXT_PUBLIC_ — the client secret is server-only.
+LINKEDIN_CLIENT_ID=""
+LINKEDIN_CLIENT_SECRET=""
+# 32-byte key (base64) that encrypts the stored access token at rest.
+# Generate with: openssl rand -base64 32
+LINKEDIN_TOKEN_ENC_KEY=""

--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ Padrao adotado:
 - [docs/design.md] (docs/design.md)
 - [docs/login.md](docs/login.md)
 - [docs/infrastructure.md](docs/infrastructure.md)
+- [docs/linkedin-playbook.md](docs/linkedin-playbook.md)
 - [docs/database/database.png] (docs/database/database.png)
 
 ## Próximos passos

--- a/docs/linkedin-launch-checklist.md
+++ b/docs/linkedin-launch-checklist.md
@@ -1,0 +1,436 @@
+# Kiwibit no LinkedIn - guia operacional de lancamento
+
+Este arquivo e o passo a passo completo para subir a Company Page da Kiwibit no LinkedIn com voce como admin. A pagina deve parecer o canal de um time de seguranca ofensiva focado em estudos, pesquisas e writeups, nao uma vitrine de produtos.
+
+## 1. Objetivo da pagina
+
+A pagina deve transmitir tres mensagens ao mesmo tempo:
+
+1. A Kiwibit e um time de seguranca ofensiva com foco em estudos e pesquisa aplicada.
+2. A empresa publica writeups, analises tecnicas e observacoes praticas sobre falhas, vetores e mitigacao.
+3. O LinkedIn sera usado para autoridade tecnica, distribuicao de conteudo e relacionamento com a comunidade.
+
+## 2. Publico-alvo
+
+Publico principal:
+
+- Profissionais de seguranca ofensiva.
+- Pesquisadores, pentesters e pessoas de AppSec.
+- Quem acompanha estudos, writeups e analises de vulnerabilidade.
+
+Publico secundario:
+
+- Estudantes e profissionais em transicao para seguranca ofensiva.
+- Comunidade tecnica que gosta de pesquisa aplicada.
+- Recrutadores e decisores tecnicos que acompanham a maturidade do time.
+
+## 3. Tom de voz
+
+Use este padrao em toda a pagina:
+
+- Idioma principal: portugues.
+- Idioma secundario: ingles somente se houver motivo claro.
+- Tom: profissional, direto, calmo e tecnico.
+- Emojis: no maximo 0 a 2 por post, e apenas se ajudarem na leitura.
+- Estilo: frases curtas, verbos ativos, sem hype.
+- Extensao dos posts: 600 a 1.200 caracteres como base.
+
+Nao usar:
+
+- Linguagem promocional exagerada.
+- Jargoes vazios.
+- Excesso de hashtags.
+- Texto em caixa alta.
+- Humor interno que dependa de contexto demais.
+
+## 4. Textos exatos da Company Page
+
+### 4.1 Nome da pagina
+
+- Kiwibit
+
+### 4.2 Slogan / headline curta
+
+Use esta versao:
+
+- Seguranca ofensiva com foco em estudos, pesquisa e analise pratica.
+
+Alternativas curtas:
+
+- Estudos tecnicos em seguranca ofensiva e AppSec.
+- Pesquisa aplicada para entender, explorar e reduzir risco.
+
+### 4.3 Sobre / About
+
+Use esta versao principal:
+
+"A Kiwibit e um time de seguranca ofensiva focado em estudos, pesquisa aplicada e analise pratica. Publicamos writeups, exploramos vetores de ataque em ambiente controlado e transformamos observacoes tecnicas em conhecimento util para AppSec, pentest e hardening. Nosso foco e estudar como falhas surgem, como se comportam e como podem ser mitigadas com criterio."
+
+Use esta versao mais curta, se o espaco da pagina ficar melhor assim:
+
+"A Kiwibit e um time de seguranca ofensiva voltado a estudos e pesquisa aplicada. Produzimos analises praticas, writeups e conteudo tecnico sobre ataque, exploracao responsavel e reducao de risco."
+
+### 4.4 Site
+
+- https://kiwibit.com.br
+
+### 4.5 Industria
+
+- Computer and Network Security
+
+### 4.6 Tipo de empresa
+
+- Privately Held
+
+### 4.7 Sede
+
+- Sao Jose dos Campos, SP, Brasil
+
+### 4.8 Tamanho da empresa
+
+Escolha a faixa mais fiel ao time real. Nao inflar.
+
+### 4.9 Ano de fundacao
+
+Preencher com o ano real de inicio da operacao formal da marca.
+
+### 4.10 Especialidades
+
+Use estas especialidades, nessa ordem se o LinkedIn permitir:
+
+- Offensive Security
+- Security Research
+- Vulnerability Research
+- Web Security
+- Reverse Engineering
+- Exploit Development
+- AppSec
+- Threat Modeling
+
+### 4.11 CTA da pagina
+
+- Visitar site
+
+Se a estrategia virar comunidade ou estudos, testar:
+
+- Saiba mais
+
+### 4.12 Banner / capa
+
+Texto para a imagem de capa:
+
+- Linha principal: Seguranca ofensiva com foco em estudos, pesquisa e analise pratica
+- Linha secundaria: Writeups, vulnerabilidade, exploracao responsavel e conteudo tecnico
+
+Se a imagem ficar muito carregada, use apenas o texto principal.
+
+### 4.13 Secao Featured / destaques
+
+Use apenas 3 tipos de conteudo:
+
+- Conteudo tecnico de blog.
+- Writeup ou estudo de vulnerabilidade.
+- Post institucional sobre metodo, cultura ou pesquisa.
+
+### 4.14 About expandido, se houver espaco extra
+
+Se a pagina permitir uma descricao mais longa, use estes tres blocos:
+
+1. O que fazemos: pesquisa ofensiva, estudos tecnicos e analise de vulnerabilidades.
+2. Como trabalhamos: laboratorio, exploracao controlada, documentacao e disseminacao do aprendizado.
+3. Para quem e: quem quer estudar seguranca com profundidade e criterio.
+
+### 4.15 Palavras-chave de marca
+
+Estas palavras devem aparecer de forma consistente na pagina e nos posts:
+
+- seguranca ofensiva
+- pesquisa aplicada
+- writeup
+- analise de vulnerabilidade
+- AppSec
+- pentest
+- exploracao responsavel
+- engenharia reversa
+
+### 4.16 Services, se a aba estiver disponivel
+
+Se o LinkedIn exibir a area de services, use nomes curtos e claros apenas se isso fizer sentido para a pagina.
+
+Recomendacao de servicos:
+
+- Security Research - estudos praticos sobre falhas, vetores e exploracao controlada.
+- Offensive Security - analises de superficie de ataque e comportamento de falhas.
+- Vulnerability Research - pesquisa aplicada para entender origens e impacto de vulnerabilidades.
+- Writeups - documentacao tecnica de achados, caminhos e mitigacoes.
+- AppSec Studies - estudos que conectam pesquisa ofensiva e defesa aplicada.
+
+## 5. Mapeamento completo do que preencher
+
+| Campo            | Texto pronto                                                        | Observacao            |
+| ---------------- | ------------------------------------------------------------------- | --------------------- |
+| Page name        | Kiwibit                                                             | Nome oficial          |
+| Headline         | Seguranca ofensiva com foco em estudos, pesquisa e analise pratica. | Texto principal       |
+| About            | Texto do item 4.3                                                   | Versao longa          |
+| Website          | https://kiwibit.com.br                                              | Sem barra final       |
+| Industry         | Computer and Network Security                                       | Categoria do LinkedIn |
+| Company size     | Faixa real do time                                                  | Escolher com cuidado  |
+| Headquarters     | Sao Jose dos Campos, SP, Brasil                                     | Padronizar com o site |
+| Company type     | Privately Held                                                      | Tipo organizacional   |
+| Founded          | Ano real da marca                                                   | Preencher depois      |
+| Specialties      | Lista do item 4.10                                                  | 5 a 8 itens           |
+| CTA button       | Visitar site                                                        | Ou Saiba mais         |
+| Cover image text | Texto do item 4.12                                                  | Legivel no mobile     |
+| Featured posts   | Blog, writeup, institucional                                        | Apenas 3 grupos       |
+
+## 6. Midias que voce precisa produzir
+
+### 6.1 Obrigatorias
+
+- Logo quadrado em alta resolucao para avatar.
+- Banner horizontal para a capa.
+- Arquivo fonte editavel do banner.
+- Versao monocromatica do logo.
+
+### 6.2 Para posts
+
+- Template de post institucional.
+- Template de carrossel ou PDF para estudos tecnicos.
+- Template de capa para artigos do blog.
+- Template de quote card para insights curtos.
+
+### 6.3 Apoio editorial
+
+- Screenshots de telas, fluxos ou dashboards.
+- Diagramas simples de arquitetura ou fluxo de ataque.
+- Foto de equipe, se quiser humanizar a pagina.
+- B-roll curto de bastidores.
+- Capturas dos estudos ou writeups com capa consistente.
+
+### 6.4 Regras para as imagens
+
+- Priorizar legibilidade no feed mobile.
+- Evitar muito texto dentro da arte.
+- Manter margem de seguranca nas bordas.
+- Usar contraste alto entre fundo e tipografia.
+- Repetir poucos elementos visuais para fixar a marca.
+
+## 7. Passo a passo no LinkedIn, como admin
+
+### 7.1 Antes de abrir o LinkedIn
+
+1. Tenha a conta pessoal que sera admin logada.
+2. Confirme que voce tem permissao para representar a empresa.
+3. Separe o logo e o banner em arquivos prontos.
+4. Tenha os textos do About, slogan e especialidades em uma nota.
+5. Separe pelo menos 3 posts iniciais.
+
+### 7.2 Criar a Company Page
+
+1. Entre no LinkedIn com sua conta pessoal.
+2. No menu superior, clique em For Business ou o menu equivalente de empresas.
+3. Clique em Create a Company Page, Create Page ou opcao equivalente.
+4. Selecione Company.
+5. Preencha o nome da pagina com Kiwibit.
+6. Preencha a URL publica, se o LinkedIn pedir.
+7. Escolha a industria Computer and Network Security.
+8. Escolha o tamanho da empresa.
+9. Escolha o tipo Privately Held.
+10. Marque a confirmacao de que voce representa a empresa.
+11. Clique em Create page ou Create Page para submeter.
+
+### 7.2.1 Onde cada informacao vai
+
+| Informacao     | Onde preencher no LinkedIn        |
+| -------------- | --------------------------------- |
+| Nome da pagina | Campo de page name / company name |
+| URL publica    | Campo de page URL, se solicitado  |
+| Industria      | Campo de industry                 |
+| Tamanho        | Campo de company size             |
+| Tipo           | Campo de company type             |
+| Slogan         | Campo de headline / tagline       |
+| About          | Campo de description / about      |
+| Site           | Campo de website                  |
+| Sede           | Campo de location / headquarters  |
+| Especialidades | Campo de specialties              |
+| CTA            | Campo de call to action           |
+| Logo           | Avatar da pagina                  |
+| Banner         | Cover image / background          |
+
+### 7.3 Configurar a pagina depois de criada
+
+1. Abra a pagina da empresa.
+2. Clique em Admin tools.
+3. Clique em Edit Page ou Manage Page.
+4. Cole o slogan no campo de headline ou tagline.
+5. Cole o texto do About.
+6. Confirme o site.
+7. Confirme sede, tipo e tamanho.
+8. Salve as alteracoes.
+
+### 7.4 Subir o logo
+
+1. Na pagina da empresa, clique sobre o avatar.
+2. Escolha Upload photo ou Edit logo.
+3. Envie o logo quadrado.
+4. Ajuste o enquadramento.
+5. Clique em Save.
+
+### 7.5 Subir a capa
+
+1. Clique sobre a imagem de capa.
+2. Escolha Upload banner ou Edit background.
+3. Envie o banner horizontal.
+4. Verifique se o texto ficou centralizado.
+5. Confira a leitura no recorte mobile.
+6. Clique em Save.
+
+### 7.6 Configurar as especialidades
+
+1. Abra a secao de details da pagina.
+2. Localize specialties ou industry specialties.
+3. Adicione os itens do bloco 4.10.
+4. Salve.
+
+### 7.7 Configurar o CTA
+
+1. Abra a area de call to action.
+2. Escolha Visit website.
+3. Confirme o link https://kiwibit.com.br.
+4. Salve.
+
+### 7.8 Adicionar admins
+
+1. Abra Admin tools.
+2. Clique em Manage admins.
+3. Adicione sua conta como super admin, content admin ou cargo equivalente.
+4. Adicione um admin de reserva, se houver.
+5. Confirme o acesso.
+
+### 7.9 Onde clicar para cada parte da pagina
+
+| O que editar | Caminho no LinkedIn                                          |
+| ------------ | ------------------------------------------------------------ |
+| Logo         | Page home > clicar no avatar > Upload photo / Edit logo      |
+| Banner       | Page home > clicar na capa > Upload banner / Edit background |
+| Headline     | Admin tools > Edit Page > headline / tagline                 |
+| About        | Admin tools > Edit Page > description                        |
+| Website      | Admin tools > Edit Page > website                            |
+| Industry     | Admin tools > Edit Page > industry                           |
+| Size         | Admin tools > Edit Page > company size                       |
+| Type         | Admin tools > Edit Page > company type                       |
+| Headquarters | Admin tools > Edit Page > location                           |
+| Specialties  | Admin tools > Edit Page > specialties                        |
+| CTA          | Admin tools > Edit Page > call to action                     |
+| Admins       | Admin tools > Manage admins                                  |
+| First post   | Page home > Start a post                                     |
+
+## 8. Textos prontos para os primeiros posts
+
+### 8.1 Post 1 - apresentacao institucional
+
+Titulo sugerido:
+
+- Kiwibit no LinkedIn
+
+Texto pronto:
+
+```text
+A Kiwibit publica estudos, writeups e analises praticas em seguranca ofensiva.
+
+Nos estudamos vulnerabilidades, exploramos cenarios em ambiente controlado e documentamos o que aprendemos.
+
+Se voce gosta de conteudo tecnico com profundidade, siga a pagina.
+```
+
+### 8.2 Post 2 - conteudo tecnico do blog
+
+Titulo sugerido:
+
+- Study: API Hardening Checklist for Production Teams
+
+Texto pronto:
+
+```text
+Muitos times deixam seguranca para o fim e acabam pagando com retrabalho.
+
+Neste estudo, mostramos um checklist simples para endurecer APIs antes que o risco cresca.
+
+Leia no blog: https://kiwibit.com.br/blog/api-hardening-checklist
+```
+
+### 8.3 Post 3 - visao da Kiwibit sobre risco real
+
+Titulo sugerido:
+
+- Seguranca ofensiva tambem e estudo
+
+Texto pronto:
+
+```text
+Seguranca ofensiva nao e so ataque: e pesquisa, metodo e documentacao.
+
+Quando a pesquisa e feita com criterio, a equipe entende melhor como as falhas surgem e como se propagam.
+
+A nossa visao e transformar estudo tecnico em aprendizado util para AppSec, pentest e hardening.
+```
+
+### 8.4 Resposta curta para comentarios
+
+Se alguem comentar, use respostas objetivas como:
+
+- Obrigado por acompanhar.
+- Faz sentido para o nosso contexto.
+- Vamos publicar mais estudos assim por aqui.
+- Se quiser trocar ideia sobre o tema, estamos por aqui.
+
+## 9. Ordem recomendada de publicacao
+
+1. Criar a pagina.
+2. Inserir o logo.
+3. Inserir a capa.
+4. Preencher slogan e About.
+5. Preencher industria, sede, tipo e tamanho.
+6. Inserir especialidades.
+7. Ajustar o CTA.
+8. Adicionar admins.
+9. Subir os 3 posts iniciais.
+10. Revisar a pagina no desktop e no mobile.
+11. Publicar oficialmente.
+
+## 10. Checklist final antes de clicar em publicar
+
+- Nome da pagina correto.
+- Slogan final aprovado.
+- About final aprovado.
+- URL do site correta.
+- Capa legivel no mobile.
+- Logo com boa qualidade.
+- Especialidades coerentes.
+- CTA correto.
+- Admins cadastrados.
+- Primeiros posts prontos.
+
+## 11. Estrategia editorial depois do lancamento
+
+- 1 a 2 posts por semana como base.
+- Reaproveitar artigos do blog com resumo e link.
+- Publicar writeups, estudos e analises tecnicas quando houver contexto real.
+- Publicar bastidores de pesquisa com moderação.
+- Nao publicar apenas por frequencia.
+
+## 12. Texto de descricao do PR, se esta documentacao for enviada para staging
+
+Titulo sugerido:
+
+- docs: linkedin offensive security communication strategy
+
+Corpo sugerido:
+
+```text
+Relacionado a issue #85.
+
+Este PR documenta a estrategia de comunicacao da Company Page da Kiwibit no LinkedIn, com publico-alvo, tom de voz, textos prontos, midias necessarias e direcao de design.
+
+Nao ha mudanca de codigo, apenas documentacao operacional para suportar o lancamento da pagina.
+```

--- a/docs/linkedin-playbook.md
+++ b/docs/linkedin-playbook.md
@@ -1,0 +1,367 @@
+# Kiwibit no LinkedIn - Playbook de comunicacao
+
+Este documento define a estrategia editorial e visual da Company Page da Kiwibit no LinkedIn. A pagina deve parecer o canal de um time de seguranca ofensiva focado em estudos, pesquisa aplicada e analise tecnica, nao uma vitrine de produtos ou servicos.
+
+## 1. Objetivo da pagina
+
+A pagina deve transmitir tres mensagens ao mesmo tempo:
+
+1. A Kiwibit e um time de seguranca ofensiva com foco em estudos e pesquisa aplicada.
+2. A empresa publica writeups, analises tecnicas e observacoes praticas sobre falhas, vetores e mitigacao.
+3. O LinkedIn sera usado para autoridade tecnica, distribuicao de conteudo e relacionamento com a comunidade.
+
+## 2. Publico-alvo prioritario
+
+Publico primario:
+
+- Profissionais de seguranca ofensiva.
+- Pesquisadores, pentesters e pessoas de AppSec.
+- Quem acompanha estudos, writeups e analises de vulnerabilidade.
+
+Publico secundario:
+
+- Estudantes e profissionais em transicao para seguranca ofensiva.
+- Comunidade tecnica que gosta de pesquisa aplicada.
+- Recrutadores e decisores tecnicos que acompanham a maturidade do time.
+
+## 3. Posicionamento recomendado
+
+A Kiwibit deve aparecer como um time de seguranca ofensiva com foco em estudos e pesquisa aplicada, com linguagem objetiva e pouca ostentacao visual. A mensagem central e:
+
+"Ajudamos pessoas a estudar seguranca ofensiva com criterio, metodo e profundidade tecnica."
+
+Pilares de mensagem:
+
+- Seguranca ofensiva como estudo, nao como performance.
+- Linguagem tecnica, mas acessivel para a comunidade.
+- Credibilidade por pesquisa, processo e consistencia.
+- Foco em entendimento real de falhas, vetores e mitigacao.
+
+## 4. Tom de voz e estilo
+
+Recomendacao principal:
+
+- Idioma: portugues como padrao. Ingles apenas quando houver objetivo claro de alcance internacional.
+- Tom: profissional, direto, calmo e tecnico.
+- Emojis: usar com muita parcimonia. Se usar, limitar a 0 a 2 por post e apenas quando ajudarem na leitura.
+- Tamanho: curtos a medios. Em geral, 600 a 1.200 caracteres por post ja e suficiente.
+- Frases: preferir frases curtas, verbos ativos e pouca adjetivacao.
+
+Nao usar:
+
+- Linguagem de hype, promessa exagerada ou jargoes vazios.
+- Excesso de hashtags.
+- Texto em caixa alta, salvo em elementos graficos da marca.
+- Humor interno que dependa de contexto muito especifico.
+
+## 5. Estrutura da pagina e textos a preencher
+
+### 5.1 Nome da pagina
+
+Texto:
+
+- Kiwibit
+
+### 5.2 Slogan / headline curta
+
+Recomendacao principal:
+
+- Seguranca ofensiva com foco em estudos, pesquisa e analise pratica.
+
+Alternativas curtas:
+
+- Estudos tecnicos em seguranca ofensiva e AppSec.
+- Pesquisa aplicada para entender, explorar e reduzir risco.
+
+### 5.3 Sobre / descricao da empresa
+
+Texto recomendado para a secao About:
+
+"A Kiwibit e um time de seguranca ofensiva focado em estudos, pesquisa aplicada e analise pratica. Publicamos writeups, exploramos vetores de ataque em ambiente controlado e transformamos observacoes tecnicas em conhecimento util para AppSec, pentest e hardening. Nosso foco e estudar como falhas surgem, como se comportam e como podem ser mitigadas com criterio."
+
+Versao mais curta:
+
+"A Kiwibit e um time de seguranca ofensiva voltado a estudos e pesquisa aplicada. Produzimos analises praticas, writeups e conteudo tecnico sobre ataque, exploracao responsavel e reducao de risco."
+
+### 5.4 Website
+
+Texto:
+
+- https://kiwibit.com.br
+
+### 5.5 Industria
+
+Recomendacao:
+
+- Computer and Network Security
+
+### 5.6 Tamanho da empresa
+
+Texto:
+
+- Escolher a faixa mais fiel ao tamanho real do time no momento da publicacao.
+
+### 5.7 Sede
+
+Texto:
+
+- Sao Jose dos Campos, SP, Brasil
+
+### 5.8 Tipo de empresa
+
+Recomendacao:
+
+- Privately Held
+
+### 5.9 Ano de fundacao
+
+Texto:
+
+- Preencher com o ano real de inicio da operacao formal da marca.
+
+### 5.10 Especialidades
+
+Use entre 5 e 8 especialidades, sem exagero.
+
+Recomendacao de lista:
+
+- Offensive Security
+- Security Research
+- Vulnerability Research
+- Web Security
+- Reverse Engineering
+- Exploit Development
+- AppSec
+- Threat Modeling
+
+### 5.11 CTA da pagina
+
+Recomendacao:
+
+- Visitar site
+
+Se a estrategia virar comunidade ou estudos, testar:
+
+- Saiba mais
+
+### 5.12 Banner / capa
+
+Texto para a imagem de capa:
+
+- Linha principal: Seguranca ofensiva com foco em estudos, pesquisa e analise pratica
+- Linha secundaria: Writeups, vulnerabilidade, exploracao responsavel e conteudo tecnico
+
+Se a capa ficar muito carregada, manter apenas a linha principal.
+
+### 5.13 Secao Featured / destaques
+
+Se a pagina usar posts em destaque, o texto-base de cada item deve cair em um destes grupos:
+
+- Conteudo tecnico de blog.
+- Writeup ou estudo de vulnerabilidade.
+- Post institucional sobre metodo, cultura ou pesquisa.
+
+### 5.14 Secao About expandida opcional
+
+Se houver espaco para um texto mais longo, usar tres blocos:
+
+1. O que fazemos: pesquisa ofensiva, estudos tecnicos e analise de vulnerabilidades.
+2. Como trabalhamos: laboratorio, exploracao controlada, documentacao e disseminacao do aprendizado.
+3. Para quem e: quem quer estudar seguranca com profundidade e criterio.
+
+### 5.15 Palavras-chave de marca
+
+Estas palavras devem aparecer de forma consistente ao longo da pagina e dos posts:
+
+- seguranca ofensiva
+- pesquisa aplicada
+- writeup
+- analise de vulnerabilidade
+- AppSec
+- pentest
+- exploracao responsavel
+- engenharia reversa
+
+### 5.16 Services, se a aba estiver disponivel
+
+Se o LinkedIn exibir a area de services, use nomes curtos e claros apenas se isso fizer sentido para a pagina.
+
+Recomendacao de servicos:
+
+- Security Research - estudos praticos sobre falhas, vetores e exploracao controlada.
+- Offensive Security - analises de superficie de ataque e comportamento de falhas.
+- Vulnerability Research - pesquisa aplicada para entender origens e impacto de vulnerabilidades.
+- Writeups - documentacao tecnica de achados, caminhos e mitigacoes.
+- AppSec Studies - estudos que conectam pesquisa ofensiva e defesa aplicada.
+
+## 6. Inventario de textos por secao da pagina
+
+Use esta lista como checklist de publicacao.
+
+| Secao          | Texto que precisa existir                | Observacao                         |
+| -------------- | ---------------------------------------- | ---------------------------------- |
+| Nome           | Kiwibit                                  | Ja definido                        |
+| Slogan         | 1 frase curta de posicionamento          | Ver item 5.2                       |
+| About          | 1 a 2 paragrafos                         | Ver item 5.3                       |
+| Website        | URL canonica da empresa                  | Sem barra final                    |
+| Industria      | Categoria oficial do LinkedIn            | Escolher a mais precisa            |
+| Tamanho        | Faixa de funcionarios                    | Preencher com a realidade          |
+| Sede           | Cidade, estado e pais                    | Padronizar com o site              |
+| Tipo           | Tipo juridico/organizacional             | Escolha consistente                |
+| Fundacao       | Ano de inicio                            | Preencher com dado real            |
+| Especialidades | Lista curta de palavras-chave            | Nao inflar a lista                 |
+| CTA            | Botao principal da pagina                | Deve refletir objetivo             |
+| Capa           | Headline + subheadline ou headline unica | Leitura rapida no mobile           |
+| Destaques      | Titulos, descricoes e links              | Priorizar blog, writeups e estudos |
+
+## 7. Midias que precisam ser produzidas
+
+### 7.1 Assets institucionais obrigatorios
+
+- Logo quadrado em alta resolucao para avatar da pagina.
+- Banner/capa horizontal com composicao segura para recorte mobile.
+- Arquivo fonte editavel do banner.
+- Versao monocromatica do logo para uso em posts e thumbnails.
+
+### 7.2 Templates para posts
+
+- Template de imagem unica para posts institucionais.
+- Template de carrossel/pdf para estudos tecnicos mais longos.
+- Template de capa para artigos do blog republicados no LinkedIn.
+- Template de quote card para insights curtos.
+
+### 7.3 Midias de apoio editorial
+
+- Screenshots de telas, dashboards ou fluxos quando fizer sentido.
+- Diagramas simples de arquitetura ou fluxo de ataque.
+- Foto de equipe ou retratos padronizados, se a pagina for humanizada.
+- B-roll curto de bastidores, workshop, quadro branco ou setup de trabalho.
+- Capturas dos estudos ou writeups com capa consistente.
+
+### 7.4 Regras visuais para os ativos
+
+- Priorizar legibilidade no feed mobile.
+- Evitar muito texto dentro da imagem.
+- Manter margem de seguranca generosa nas bordas.
+- Usar contraste forte entre fundo e tipografia.
+- Repetir poucos elementos visuais para criar memoria de marca.
+
+## 8. Direcao de design da pagina
+
+O design deve comunicar tres coisas: confianca, criterio e competencia tecnica.
+
+Recomendacao visual:
+
+- Paleta principal: grafite, branco, cinza frio e um acento controlado em verde ou azul.
+- Linguagem grafica: limpa, editorial, pouco ornamental.
+- Tipografia dos assets: sans-serif forte, com pesos claros e contraste alto.
+- Fotos: se usadas, devem parecer reais e profissionais, nao banco de imagens generico.
+- Composicao: muito espaco em branco, hierarquia clara e blocos curtos.
+
+O que evitar:
+
+- Estetica exageradamente cyberpunk ou agressiva para a capa da Company Page.
+- Elementos visuais demais competindo com o texto.
+- Cores muito saturadas em excesso.
+- Pseudo-efeitos de "hacker" que reduzem credibilidade comercial.
+
+## 9. Estrategia de conteudo
+
+### 9.1 Conteudo base no lancamento
+
+Para a estreia da pagina, publicar pelo menos:
+
+- 1 post institucional de apresentacao.
+- 1 post tecnico adaptado de um estudo do blog.
+- 1 post com foco em problema real de seguranca ofensiva e visao da Kiwibit.
+
+### 9.2 Conteudo continuo
+
+Tipos recomendados:
+
+- Blog posts republicados com resumo e link.
+- Writeups e estudos de vulnerabilidade.
+- Posts opinativos tecnicos com visao clara.
+- Bastidores de pesquisa e rotina do time.
+- Conteudo de recrutamento apenas quando houver vaga real.
+
+### 9.3 Frequencia sugerida
+
+- Baseline: 1 a 2 publicacoes por semana.
+- Com mais maturidade editorial: 3 por semana, se houver insumo real.
+- Evitar periodicidade artificial se nao houver conteudo relevante.
+
+## 10. Modelo padrao para posts do blog
+
+Use este formato quando um artigo for republicado no LinkedIn.
+
+```text
+[gancho de 1 linha que apresenta o problema ou insight]
+
+[2 a 4 linhas resumindo a ideia principal do artigo, sem repetir o texto inteiro]
+
+No blog: [titulo do post]
+[link]
+
+[1 linha final com convite neutro]
+```
+
+Exemplo:
+
+```text
+Muitos times tratam seguranca como etapa final. O resultado e sempre o mesmo: retrabalho, risco acumulado e pouca visibilidade.
+
+Neste estudo, mostramos um jeito mais pratico de pensar AppSec: reduzir superficie de ataque cedo, priorizar o que realmente importa e manter a entrega fluindo.
+
+No blog: API Hardening Checklist for Production Teams
+https://kiwibit.com.br/blog/api-hardening-checklist
+
+Se fizer sentido para seu contexto, vale ler o passo a passo completo.
+```
+
+## 11. Quem faz o que
+
+Definir responsabilidades evita a pagina virar reativa.
+
+### Admin da pagina
+
+- Garante acesso, configuracao e continuidade da Company Page.
+- Mantem controle de permissao e recuperacao de conta.
+
+### Responsavel por conteudo
+
+- Redige a primeira versao dos posts.
+- Adapta estudos e writeups para formato LinkedIn.
+- Mantem calendario editorial.
+
+### Revisor tecnico
+
+- Valida precisao tecnica.
+- Evita exageros, erros de claims e incoerencias.
+
+### Revisor de marca
+
+- Valida tom, clareza e alinhamento com posicionamento.
+
+### Community manager / resposta a comentarios
+
+- Responde comentarios, mensagens e interacoes publicas.
+- Encaminha oportunidades tecnicas quando necessario.
+
+## 12. Regras praticas para manter consistencia
+
+- Nao publicar antes de revisar alinhamento com objetivo do post.
+- Nao transformar todo post em venda direta.
+- Nao copiar o blog integralmente para o LinkedIn.
+- Nao misturar tom institucional com linguagem de meme.
+- Nao abandonar a pagina depois do lancamento.
+
+## 13. Resumo executivo
+
+Se a pagina tiver que começar simples, a ordem de prioridade e:
+
+1. Ajustar nome, slogan, About, especialidades e CTA.
+2. Produzir logo, capa e templates de post.
+3. Definir responsaveis por aprovacao e resposta.
+4. Publicar um lote inicial de conteudo coerente.
+5. Repetir o ciclo com consistencia.

--- a/prisma/migrations/20260806120000_linkedin_connection/migration.sql
+++ b/prisma/migrations/20260806120000_linkedin_connection/migration.sql
@@ -1,0 +1,22 @@
+-- CreateTable
+CREATE TABLE "linkedin_connections" (
+    "id" UUID NOT NULL,
+    "member_id" UUID NOT NULL,
+    "linkedin_sub" TEXT NOT NULL,
+    "scope" TEXT NOT NULL,
+    "access_token_enc" TEXT NOT NULL,
+    "access_token_expiry" TIMESTAMP(3) NOT NULL,
+    "connected_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "linkedin_connections_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "linkedin_connections_member_id_key" ON "linkedin_connections"("member_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "linkedin_connections_linkedin_sub_key" ON "linkedin_connections"("linkedin_sub");
+
+-- AddForeignKey
+ALTER TABLE "linkedin_connections" ADD CONSTRAINT "linkedin_connections_member_id_fkey" FOREIGN KEY ("member_id") REFERENCES "members"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -40,9 +40,39 @@ model Member {
   createdAt  DateTime @default(now()) @map("created_at")
   updatedAt  DateTime @updatedAt @map("updated_at")
 
-  user User? @relation(fields: [userId], references: [id], onDelete: SetNull)
+  user               User?               @relation(fields: [userId], references: [id], onDelete: SetNull)
+  linkedinConnection LinkedinConnection?
 
   @@map("members")
+}
+
+/// LinkedIn OAuth link for a member, used to sync the profile photo (issue #80).
+///
+/// A dedicated table rather than columns on `Member`: `Member` is read by public
+/// queries, and the access token must never ride along in those selects. The
+/// token is stored encrypted at rest (AES-256-GCM, see `token-crypto.ts`) and
+/// only ever decrypted server-side.
+///
+/// The current scope is basic OIDC (`openid profile email`), whose token cannot
+/// post. Auto-posting (issue #81) will extend the scope, re-consent, and add a
+/// refresh-token column here.
+model LinkedinConnection {
+  id       String @id @default(uuid()) @db.Uuid
+  memberId String @unique @map("member_id") @db.Uuid
+  /// OIDC `sub` claim — the stable LinkedIn identity. Unique so two members
+  /// cannot claim the same LinkedIn account.
+  linkedinSub String @unique @map("linkedin_sub")
+  /// Space-separated scopes granted at connection time.
+  scope String
+  /// Access token, encrypted as `iv:authTag:ciphertext` (all base64).
+  accessTokenEnc    String   @map("access_token_enc")
+  accessTokenExpiry DateTime @map("access_token_expiry")
+  connectedAt       DateTime @default(now()) @map("connected_at")
+  updatedAt         DateTime @updatedAt @map("updated_at")
+
+  member Member @relation(fields: [memberId], references: [id], onDelete: Cascade)
+
+  @@map("linkedin_connections")
 }
 
 model Project {

--- a/src/app/(internal)/admin/members/[id]/edit/page.tsx
+++ b/src/app/(internal)/admin/members/[id]/edit/page.tsx
@@ -3,6 +3,7 @@ import { prisma } from '@/shared/lib/prisma';
 import { requireAdminPageSession } from '@/shared/lib/page-auth';
 import { AdminMemberForm } from '@/features/admin/members/ui/admin-member-form';
 import { MemberAccountPanel } from '@/features/admin/members/ui/member-account-panel';
+import { MemberLinkedinPanel } from '@/features/admin/members/ui/member-linkedin-panel';
 import { DeleteButton } from '@/shared/ui/delete-button';
 import { AdminPageShell } from '@/shared/ui/admin-page-shell';
 
@@ -23,10 +24,16 @@ export default async function EditMemberPage({ params }: Params) {
       avatarPath: true,
       // The screen must always show whether an account is associated.
       user: { select: { id: true, email: true, role: true } },
+      // Never select the token here — only whether/when it was connected.
+      linkedinConnection: { select: { connectedAt: true } },
     },
   });
 
   if (!member) notFound();
+
+  // "Each connects their own": the panel is actionable only for the member
+  // linked to the signed-in user's account.
+  const isLinkedinOwner = member.user?.id === session.user.id;
 
   return (
     <AdminPageShell
@@ -46,6 +53,12 @@ export default async function EditMemberPage({ params }: Params) {
         memberId={member.id}
         account={member.user}
         canAssignPrivileged={session.user.role === 'admin'}
+      />
+      <MemberLinkedinPanel
+        memberId={member.id}
+        isOwner={isLinkedinOwner}
+        isConnected={member.linkedinConnection !== null}
+        connectedAt={member.linkedinConnection?.connectedAt.toISOString() ?? null}
       />
     </AdminPageShell>
   );

--- a/src/app/api/admin/members/[id]/linkedin/connect/route.ts
+++ b/src/app/api/admin/members/[id]/linkedin/connect/route.ts
@@ -1,0 +1,56 @@
+import { randomUUID } from 'node:crypto';
+import { NextResponse, type NextRequest } from 'next/server';
+import { prisma } from '@/shared/lib/prisma';
+import { requireAdminSession } from '@/shared/lib/api-helpers';
+import { authorizeUrl, isLinkedinConfigured, LINKEDIN_OAUTH_COOKIE } from '@/shared/lib/linkedin';
+import { isTokenCryptoConfigured } from '@/shared/lib/token-crypto';
+import { absoluteUrl } from '@/shared/lib/seo';
+
+type Params = { params: Promise<{ id: string }> };
+
+function backToEdit(id: string, status: 'error' | 'forbidden') {
+  return NextResponse.redirect(absoluteUrl(`/admin/members/${id}/edit?linkedin=${status}`));
+}
+
+/**
+ * GET /api/admin/members/[id]/linkedin/connect
+ *
+ * Starts the LinkedIn OAuth flow for the member's OWN profile, then redirects to
+ * LinkedIn's consent screen. "Each connects their own": only the signed-in user
+ * whose account is linked to this member may connect.
+ *
+ * A GET (not a fetch) because it ends in a top-level browser redirect to
+ * LinkedIn; the CSRF `state` is mirrored into an httpOnly cookie and checked on
+ * the callback.
+ */
+export async function GET(_request: NextRequest, { params }: Params) {
+  const { session, response } = await requireAdminSession();
+  if (response || !session) return response;
+
+  const { id } = await params;
+
+  if (!isLinkedinConfigured() || !isTokenCryptoConfigured()) {
+    return backToEdit(id, 'error');
+  }
+
+  const member = await prisma.member.findUnique({ where: { id }, select: { userId: true } });
+  if (!member || member.userId !== session.user.id) {
+    return backToEdit(id, 'forbidden');
+  }
+
+  const state = randomUUID();
+  const redirect = NextResponse.redirect(authorizeUrl(state));
+
+  // Binds the callback to this browser and this member. Short-lived; cleared on
+  // the callback. `lax` so it rides the top-level GET navigation back from
+  // LinkedIn; `httpOnly` so client JS cannot read the CSRF value.
+  redirect.cookies.set(LINKEDIN_OAUTH_COOKIE, `${state}:${id}`, {
+    httpOnly: true,
+    sameSite: 'lax',
+    secure: process.env.NODE_ENV === 'production',
+    path: '/',
+    maxAge: 600,
+  });
+
+  return redirect;
+}

--- a/src/app/api/admin/members/[id]/linkedin/route.spec.ts
+++ b/src/app/api/admin/members/[id]/linkedin/route.spec.ts
@@ -1,0 +1,55 @@
+import { DELETE as disconnectLinkedin } from './route';
+import { prisma } from '@/shared/lib/prisma';
+import { makeReq, paramsFor, mockAuth } from '@/shared/test-utils/spec-helpers';
+
+// ADMIN_SESSION.user.id is 'uid-1'.
+
+describe('DELETE /api/admin/members/[id]/linkedin', () => {
+  it('returns 401 when unauthenticated', async () => {
+    mockAuth(false);
+    const res = await disconnectLinkedin(
+      makeReq('http://localhost/api/admin/members/mid-1/linkedin', undefined, 'DELETE'),
+      paramsFor('mid-1'),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 404 when the member does not exist', async () => {
+    mockAuth();
+    (prisma.member.findUnique as jest.Mock).mockResolvedValue(null);
+    const res = await disconnectLinkedin(
+      makeReq('http://localhost/api/admin/members/mid-1/linkedin', undefined, 'DELETE'),
+      paramsFor('mid-1'),
+    );
+    expect(res.status).toBe(404);
+    expect(prisma.linkedinConnection.deleteMany).not.toHaveBeenCalled();
+  });
+
+  it('forbids disconnecting a member that is not your own account', async () => {
+    mockAuth();
+    // Linked to a different user than the signed-in one.
+    (prisma.member.findUnique as jest.Mock).mockResolvedValue({ userId: 'someone-else' });
+    const res = await disconnectLinkedin(
+      makeReq('http://localhost/api/admin/members/mid-1/linkedin', undefined, 'DELETE'),
+      paramsFor('mid-1'),
+    );
+    expect(res.status).toBe(403);
+    expect(prisma.linkedinConnection.deleteMany).not.toHaveBeenCalled();
+  });
+
+  it('deletes the connection for your own member', async () => {
+    mockAuth();
+    (prisma.member.findUnique as jest.Mock).mockResolvedValue({ userId: 'uid-1' });
+    (prisma.linkedinConnection.deleteMany as jest.Mock).mockResolvedValue({ count: 1 });
+
+    const res = await disconnectLinkedin(
+      makeReq('http://localhost/api/admin/members/mid-1/linkedin', undefined, 'DELETE'),
+      paramsFor('mid-1'),
+    );
+
+    expect(res.status).toBe(200);
+    expect(prisma.linkedinConnection.deleteMany).toHaveBeenCalledWith({
+      where: { memberId: 'mid-1' },
+    });
+  });
+});

--- a/src/app/api/admin/members/[id]/linkedin/route.ts
+++ b/src/app/api/admin/members/[id]/linkedin/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/shared/lib/prisma';
+import { requireAdminSession, apiError } from '@/shared/lib/api-helpers';
+
+type Params = { params: Promise<{ id: string }> };
+
+/**
+ * DELETE /api/admin/members/[id]/linkedin
+ *
+ * Disconnects the member's LinkedIn: deletes the stored (encrypted) token and
+ * link. "Each connects their own" — only the owner of this member's account may
+ * disconnect. The current avatar is kept; unlinking is not the same as clearing
+ * the photo.
+ */
+export async function DELETE(_request: Request, { params }: Params) {
+  const { session, response } = await requireAdminSession();
+  if (response || !session) return response;
+
+  const { id } = await params;
+
+  const member = await prisma.member.findUnique({ where: { id }, select: { userId: true } });
+  if (!member) return apiError('NOT_FOUND', 'Member not found.', 404);
+  if (member.userId !== session.user.id) {
+    return apiError('FORBIDDEN', 'You can only disconnect your own LinkedIn.', 403);
+  }
+
+  // Idempotent: nothing to delete is still success from the caller's view.
+  await prisma.linkedinConnection.deleteMany({ where: { memberId: id } });
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/admin/members/linkedin/callback/route.ts
+++ b/src/app/api/admin/members/linkedin/callback/route.ts
@@ -1,0 +1,135 @@
+import { randomUUID } from 'node:crypto';
+import { NextResponse, type NextRequest } from 'next/server';
+import { prisma } from '@/shared/lib/prisma';
+import { requireAdminSession } from '@/shared/lib/api-helpers';
+import {
+  exchangeCode,
+  fetchUserinfo,
+  isLinkedinConfigured,
+  LINKEDIN_OAUTH_COOKIE,
+  parseOauthCookie,
+} from '@/shared/lib/linkedin';
+import { encryptToken, isTokenCryptoConfigured } from '@/shared/lib/token-crypto';
+import { deleteObjects, isStorageConfigured, putObject } from '@/shared/lib/storage';
+import { extensionForType, sniffImageType } from '@/shared/lib/validate-image-file';
+import { absoluteUrl } from '@/shared/lib/seo';
+
+/**
+ * GET /api/admin/members/linkedin/callback
+ *
+ * Fixed redirect URI for the LinkedIn OAuth flow — the member id travels in the
+ * `state` cookie, not the URL, since LinkedIn matches the redirect URI exactly.
+ *
+ * Under `/api/admin`, so `proxy.ts` already requires an admin JWT, and the
+ * `sameSite: lax` session cookie rides the top-level GET navigation back from
+ * LinkedIn.
+ */
+
+function redirectEdit(memberId: string, status: 'connected' | 'error' | 'forbidden') {
+  const redirect = NextResponse.redirect(
+    absoluteUrl(`/admin/members/${memberId}/edit?linkedin=${status}`),
+  );
+  // The one-shot OAuth cookie has served its purpose either way.
+  redirect.cookies.delete(LINKEDIN_OAUTH_COOKIE);
+  return redirect;
+}
+
+/**
+ * Downloads the LinkedIn photo and rehosts it to the OCI bucket, matching the
+ * avatar upload path. Returns the new `{ url, path }`, or null when the photo is
+ * missing/unusable or storage is unavailable — connection still succeeds, the
+ * old avatar just stays.
+ */
+async function syncPhoto(pictureUrl: string | null): Promise<{ url: string; path: string } | null> {
+  if (!pictureUrl || !isStorageConfigured()) return null;
+
+  try {
+    const response = await fetch(pictureUrl);
+    if (!response.ok) return null;
+
+    const bytes = new Uint8Array(await response.arrayBuffer());
+    // The remote bytes are attacker-influenceable; trust the magic bytes, not
+    // the Content-Type, exactly like the upload route does.
+    const type = sniffImageType(bytes);
+    if (!type) return null;
+
+    const key = `members/${randomUUID()}.${extensionForType(type)}`;
+    const result = await putObject(key, bytes, type);
+    return result.ok ? { url: result.url, path: result.key } : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function GET(request: NextRequest) {
+  const { session, response } = await requireAdminSession();
+  if (response || !session) return response;
+
+  const cookie = parseOauthCookie(request.cookies.get(LINKEDIN_OAUTH_COOKIE)?.value);
+  // With no cookie there is no member to redirect back to; land on the list.
+  if (!cookie) return NextResponse.redirect(absoluteUrl('/admin/members'));
+  const { state, memberId } = cookie;
+
+  const params = request.nextUrl.searchParams;
+  // LinkedIn returns `error` when the member declines consent.
+  if (params.get('error') || params.get('state') !== state) {
+    return redirectEdit(memberId, 'error');
+  }
+
+  const code = params.get('code');
+  if (!code || !isLinkedinConfigured() || !isTokenCryptoConfigured()) {
+    return redirectEdit(memberId, 'error');
+  }
+
+  const member = await prisma.member.findUnique({
+    where: { id: memberId },
+    select: { userId: true, avatarPath: true },
+  });
+  // Re-check ownership: the cookie is bound to a browser, not re-authorized here.
+  if (!member || member.userId !== session.user.id) {
+    return redirectEdit(memberId, 'forbidden');
+  }
+
+  try {
+    const token = await exchangeCode(code);
+    const userinfo = await fetchUserinfo(token.accessToken);
+    const photo = await syncPhoto(userinfo.picture);
+
+    const expiry = new Date(Date.now() + token.expiresInSeconds * 1000);
+    const accessTokenEnc = encryptToken(token.accessToken);
+
+    await prisma.$transaction(async (tx) => {
+      if (photo) {
+        await tx.member.update({
+          where: { id: memberId },
+          data: { avatarUrl: photo.url, avatarPath: photo.path },
+        });
+      }
+      await tx.linkedinConnection.upsert({
+        where: { memberId },
+        create: {
+          memberId,
+          linkedinSub: userinfo.sub,
+          scope: token.scope,
+          accessTokenEnc,
+          accessTokenExpiry: expiry,
+        },
+        update: {
+          linkedinSub: userinfo.sub,
+          scope: token.scope,
+          accessTokenEnc,
+          accessTokenExpiry: expiry,
+        },
+      });
+    });
+
+    // Replaced a bucket-hosted avatar: drop the old object (best-effort).
+    if (photo && member.avatarPath) {
+      await deleteObjects([member.avatarPath]);
+    }
+
+    return redirectEdit(memberId, 'connected');
+  } catch {
+    return redirectEdit(memberId, 'error');
+  }
+}

--- a/src/features/admin/members/ui/member-linkedin-panel.tsx
+++ b/src/features/admin/members/ui/member-linkedin-panel.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { apiClient } from '@/shared/api/api-client';
+import { Button } from '@/shared/ui/button';
+import { FormStatus } from '@/shared/ui/form-status';
+
+type Props = {
+  memberId: string;
+  /** True when the signed-in user's account is linked to this member. */
+  isOwner: boolean;
+  isConnected: boolean;
+  /** ISO date the LinkedIn was connected, or null. */
+  connectedAt: string | null;
+};
+
+const CONNECT_MESSAGES: Record<string, { status: 'success' | 'error'; message: string }> = {
+  connected: { status: 'success', message: 'LinkedIn conectado e foto sincronizada.' },
+  error: { status: 'error', message: 'Não foi possível conectar o LinkedIn. Tente novamente.' },
+  forbidden: { status: 'error', message: 'Você só pode conectar o seu próprio LinkedIn.' },
+};
+
+/**
+ * Connects a member's own LinkedIn to sync the profile photo (issue #80).
+ *
+ * "Each connects their own": the button only works for the member linked to the
+ * signed-in user's account. Mirrors `MemberAccountPanel` in shape and styling.
+ */
+export function MemberLinkedinPanel({
+  memberId,
+  isOwner,
+  isConnected,
+  connectedAt,
+}: Readonly<Props>) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  // Seed the banner from the OAuth redirect outcome (?linkedin=connected|error|
+  // forbidden). Derived once from the URL present on mount; the disconnect action
+  // takes over the same state afterwards.
+  const [{ status, message }, setBanner] = useState<{
+    status: 'idle' | 'submitting' | 'success' | 'error';
+    message: string;
+  }>(() => {
+    const outcome = searchParams.get('linkedin');
+    const seed = outcome ? CONNECT_MESSAGES[outcome] : undefined;
+    return seed ? { status: seed.status, message: seed.message } : { status: 'idle', message: '' };
+  });
+
+  const connectUrl = `/api/admin/members/${memberId}/linkedin/connect`;
+
+  async function handleDisconnect() {
+    setBanner({ status: 'submitting', message: '' });
+
+    const result = await apiClient.delete(connectUrl.replace('/connect', ''));
+    if (!result.ok) {
+      setBanner({ status: 'error', message: result.message });
+      return;
+    }
+
+    setBanner({ status: 'success', message: 'LinkedIn desconectado. A foto atual foi mantida.' });
+    router.refresh();
+  }
+
+  const formattedDate = connectedAt
+    ? new Date(connectedAt).toLocaleDateString('pt-BR', {
+        day: '2-digit',
+        month: '2-digit',
+        year: 'numeric',
+      })
+    : null;
+
+  return (
+    <section className="card-glow animate-fade-up delay-200 mt-6 rounded-2xl border border-white/10 bg-white/[0.03] p-6 backdrop-blur-sm">
+      <h2 className="text-xs font-semibold uppercase tracking-[0.28em] text-white/40">LinkedIn</h2>
+
+      <div className="mt-3 space-y-4">
+        <FormStatus status={status} message={message} />
+
+        {!isOwner ? (
+          <p className="text-sm text-white/50">
+            Só o próprio membro conecta seu LinkedIn, entrando com a conta dele.
+          </p>
+        ) : isConnected ? (
+          <>
+            <p className="text-sm text-white/80">
+              Conectado{formattedDate ? ` em ${formattedDate}` : ''}.
+            </p>
+            <p className="text-xs text-white/40">
+              A foto é sincronizada apenas no momento da conexão — reconecte para atualizá-la.
+            </p>
+            <div className="flex gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => (window.location.href = connectUrl)}
+              >
+                Ressincronizar foto
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => void handleDisconnect()}
+                isLoading={status === 'submitting'}
+                loadingLabel="Desconectando..."
+              >
+                Desconectar
+              </Button>
+            </div>
+          </>
+        ) : (
+          <>
+            <p className="text-sm text-white/50">
+              Conecte sua conta do LinkedIn para sincronizar a foto de perfil.
+            </p>
+            <Button size="sm" onClick={() => (window.location.href = connectUrl)}>
+              Conectar LinkedIn
+            </Button>
+          </>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/shared/lib/linkedin.spec.ts
+++ b/src/shared/lib/linkedin.spec.ts
@@ -1,0 +1,107 @@
+import {
+  authorizeUrl,
+  exchangeCode,
+  fetchUserinfo,
+  isLinkedinConfigured,
+  LINKEDIN_SCOPE,
+  parseOauthCookie,
+  redirectUri,
+} from './linkedin';
+
+describe('parseOauthCookie', () => {
+  it('splits state and member id', () => {
+    expect(parseOauthCookie('abc:member-1')).toEqual({ state: 'abc', memberId: 'member-1' });
+  });
+
+  it('keeps a member id that contains colons intact', () => {
+    // memberId is a UUID today, but the parser must not lose data on the first colon.
+    expect(parseOauthCookie('state:a:b')).toEqual({ state: 'state', memberId: 'a:b' });
+  });
+
+  it('rejects malformed or empty values', () => {
+    expect(parseOauthCookie(undefined)).toBeNull();
+    expect(parseOauthCookie('nocolon')).toBeNull();
+    expect(parseOauthCookie(':member')).toBeNull();
+    expect(parseOauthCookie('state:')).toBeNull();
+  });
+});
+
+describe('LinkedIn OAuth lib', () => {
+  const original = { ...process.env };
+
+  beforeEach(() => {
+    process.env.LINKEDIN_CLIENT_ID = 'client-123';
+    process.env.LINKEDIN_CLIENT_SECRET = 'secret-456';
+  });
+
+  afterEach(() => {
+    process.env = { ...original };
+    jest.restoreAllMocks();
+  });
+
+  it('reports configuration state', () => {
+    expect(isLinkedinConfigured()).toBe(true);
+    delete process.env.LINKEDIN_CLIENT_SECRET;
+    expect(isLinkedinConfigured()).toBe(false);
+  });
+
+  it('builds an authorize URL with the basic scope and the fixed redirect', () => {
+    const url = new URL(authorizeUrl('state-xyz'));
+    expect(url.origin + url.pathname).toBe('https://www.linkedin.com/oauth/v2/authorization');
+    expect(url.searchParams.get('response_type')).toBe('code');
+    expect(url.searchParams.get('client_id')).toBe('client-123');
+    expect(url.searchParams.get('scope')).toBe(LINKEDIN_SCOPE);
+    expect(url.searchParams.get('state')).toBe('state-xyz');
+    expect(url.searchParams.get('redirect_uri')).toBe(redirectUri());
+  });
+
+  it('exchanges a code for an access token', async () => {
+    const fetchMock = jest
+      .spyOn(global, 'fetch')
+      .mockResolvedValue(
+        new Response(
+          JSON.stringify({ access_token: 'tok', expires_in: 5184000, scope: LINKEDIN_SCOPE }),
+          { status: 200 },
+        ),
+      );
+
+    const result = await exchangeCode('the-code');
+    expect(result).toEqual({
+      accessToken: 'tok',
+      expiresInSeconds: 5184000,
+      scope: LINKEDIN_SCOPE,
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://www.linkedin.com/oauth/v2/accessToken',
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+
+  it('throws when the token exchange fails', async () => {
+    jest.spyOn(global, 'fetch').mockResolvedValue(new Response('nope', { status: 400 }));
+    await expect(exchangeCode('bad')).rejects.toThrow();
+  });
+
+  it('reads sub and picture from userinfo', async () => {
+    jest.spyOn(global, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ sub: 'linkedin-sub', picture: 'https://cdn/pic.jpg' }), {
+        status: 200,
+      }),
+    );
+
+    await expect(fetchUserinfo('tok')).resolves.toEqual({
+      sub: 'linkedin-sub',
+      picture: 'https://cdn/pic.jpg',
+    });
+  });
+
+  it('tolerates a missing picture but requires sub', async () => {
+    const spy = jest.spyOn(global, 'fetch');
+
+    spy.mockResolvedValueOnce(new Response(JSON.stringify({ sub: 'only-sub' }), { status: 200 }));
+    await expect(fetchUserinfo('tok')).resolves.toEqual({ sub: 'only-sub', picture: null });
+
+    spy.mockResolvedValueOnce(new Response(JSON.stringify({ picture: 'x' }), { status: 200 }));
+    await expect(fetchUserinfo('tok')).rejects.toThrow();
+  });
+});

--- a/src/shared/lib/linkedin.ts
+++ b/src/shared/lib/linkedin.ts
@@ -1,0 +1,124 @@
+import { absoluteUrl } from '@/shared/lib/seo';
+
+/**
+ * "Sign In with LinkedIn using OpenID Connect" OAuth, used to sync a member's
+ * profile photo (issue #80).
+ *
+ * SERVER ONLY. `LINKEDIN_CLIENT_SECRET` must never reach the browser — nothing
+ * here is `NEXT_PUBLIC_` and the module is imported solely from route handlers.
+ *
+ * Scope is the basic OIDC set: it returns name/email/`picture` and cannot post.
+ * Auto-posting (issue #81) will add `w_member_social`, a separate LinkedIn
+ * product approval, and re-consent.
+ */
+export const LINKEDIN_SCOPE = 'openid profile email';
+
+/** httpOnly cookie carrying `${state}:${memberId}` between connect and callback. */
+export const LINKEDIN_OAUTH_COOKIE = 'linkedin_oauth';
+
+/** Parses the OAuth state cookie; returns null when malformed. */
+export function parseOauthCookie(
+  value: string | undefined,
+): { state: string; memberId: string } | null {
+  if (!value) return null;
+  const separator = value.indexOf(':');
+  if (separator <= 0) return null;
+  const state = value.slice(0, separator);
+  const memberId = value.slice(separator + 1);
+  if (!state || !memberId) return null;
+  return { state, memberId };
+}
+
+const AUTHORIZE_URL = 'https://www.linkedin.com/oauth/v2/authorization';
+const TOKEN_URL = 'https://www.linkedin.com/oauth/v2/accessToken';
+const USERINFO_URL = 'https://api.linkedin.com/v2/userinfo';
+
+/** Fixed redirect URI — LinkedIn matches it exactly; the member id travels in `state`. */
+export function redirectUri(): string {
+  return absoluteUrl('/api/admin/members/linkedin/callback');
+}
+
+type LinkedinConfig = { clientId: string; clientSecret: string };
+
+function readConfig(): LinkedinConfig | null {
+  const clientId = process.env.LINKEDIN_CLIENT_ID;
+  const clientSecret = process.env.LINKEDIN_CLIENT_SECRET;
+  if (!clientId || !clientSecret) return null;
+  return { clientId, clientSecret };
+}
+
+/** True when the app has the LinkedIn OAuth credentials. */
+export function isLinkedinConfigured(): boolean {
+  return readConfig() !== null;
+}
+
+/** Authorization URL to redirect the member to for consent. */
+export function authorizeUrl(state: string): string {
+  const config = readConfig();
+  if (!config) throw new Error('LinkedIn is not configured.');
+
+  const params = new URLSearchParams({
+    response_type: 'code',
+    client_id: config.clientId,
+    redirect_uri: redirectUri(),
+    scope: LINKEDIN_SCOPE,
+    state,
+  });
+  return `${AUTHORIZE_URL}?${params.toString()}`;
+}
+
+export type TokenResult = { accessToken: string; expiresInSeconds: number; scope: string };
+
+/** Exchanges the authorization code for an access token (client secret stays server-side). */
+export async function exchangeCode(code: string): Promise<TokenResult> {
+  const config = readConfig();
+  if (!config) throw new Error('LinkedIn is not configured.');
+
+  const body = new URLSearchParams({
+    grant_type: 'authorization_code',
+    code,
+    redirect_uri: redirectUri(),
+    client_id: config.clientId,
+    client_secret: config.clientSecret,
+  });
+
+  const response = await fetch(TOKEN_URL, {
+    method: 'POST',
+    headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    body,
+  });
+  if (!response.ok) throw new Error(`LinkedIn token exchange failed (${response.status}).`);
+
+  const json = (await response.json()) as {
+    access_token?: unknown;
+    expires_in?: unknown;
+    scope?: unknown;
+  };
+  if (typeof json.access_token !== 'string') {
+    throw new Error('LinkedIn token response is missing access_token.');
+  }
+
+  return {
+    accessToken: json.access_token,
+    expiresInSeconds: typeof json.expires_in === 'number' ? json.expires_in : 0,
+    scope: typeof json.scope === 'string' ? json.scope : LINKEDIN_SCOPE,
+  };
+}
+
+export type LinkedinUserinfo = { sub: string; picture: string | null };
+
+/** Reads the OIDC userinfo endpoint for the stable `sub` and the profile `picture`. */
+export async function fetchUserinfo(accessToken: string): Promise<LinkedinUserinfo> {
+  const response = await fetch(USERINFO_URL, {
+    headers: { authorization: `Bearer ${accessToken}` },
+  });
+  if (!response.ok) throw new Error(`LinkedIn userinfo failed (${response.status}).`);
+
+  const json = (await response.json()) as { sub?: unknown; picture?: unknown };
+  if (typeof json.sub !== 'string') throw new Error('LinkedIn userinfo is missing sub.');
+
+  return {
+    sub: json.sub,
+    picture: typeof json.picture === 'string' ? json.picture : null,
+  };
+}

--- a/src/shared/lib/token-crypto.spec.ts
+++ b/src/shared/lib/token-crypto.spec.ts
@@ -1,0 +1,54 @@
+import { randomBytes } from 'node:crypto';
+import { decryptToken, encryptToken, isTokenCryptoConfigured } from './token-crypto';
+
+const VALID_KEY = randomBytes(32).toString('base64');
+
+describe('token-crypto', () => {
+  const originalKey = process.env.LINKEDIN_TOKEN_ENC_KEY;
+
+  afterEach(() => {
+    process.env.LINKEDIN_TOKEN_ENC_KEY = originalKey;
+  });
+
+  it('round-trips a token', () => {
+    process.env.LINKEDIN_TOKEN_ENC_KEY = VALID_KEY;
+    const token = 'AQXlinkedin-access-token-value';
+    expect(decryptToken(encryptToken(token))).toBe(token);
+  });
+
+  it('produces a different ciphertext each time (random IV)', () => {
+    process.env.LINKEDIN_TOKEN_ENC_KEY = VALID_KEY;
+    expect(encryptToken('same')).not.toBe(encryptToken('same'));
+  });
+
+  it('rejects a tampered ciphertext', () => {
+    process.env.LINKEDIN_TOKEN_ENC_KEY = VALID_KEY;
+    const [iv, tag, ciphertext] = encryptToken('secret').split(':');
+    const flipped = Buffer.from(ciphertext, 'base64');
+    flipped[0] ^= 0xff;
+    const tampered = [iv, tag, flipped.toString('base64')].join(':');
+    expect(() => decryptToken(tampered)).toThrow();
+  });
+
+  it('throws on a malformed payload', () => {
+    process.env.LINKEDIN_TOKEN_ENC_KEY = VALID_KEY;
+    expect(() => decryptToken('not-a-valid-payload')).toThrow();
+  });
+
+  it('reports configuration state from the key', () => {
+    process.env.LINKEDIN_TOKEN_ENC_KEY = VALID_KEY;
+    expect(isTokenCryptoConfigured()).toBe(true);
+
+    delete process.env.LINKEDIN_TOKEN_ENC_KEY;
+    expect(isTokenCryptoConfigured()).toBe(false);
+
+    // A key of the wrong length is not usable.
+    process.env.LINKEDIN_TOKEN_ENC_KEY = randomBytes(16).toString('base64');
+    expect(isTokenCryptoConfigured()).toBe(false);
+  });
+
+  it('refuses to encrypt without a valid key', () => {
+    delete process.env.LINKEDIN_TOKEN_ENC_KEY;
+    expect(() => encryptToken('x')).toThrow();
+  });
+});

--- a/src/shared/lib/token-crypto.ts
+++ b/src/shared/lib/token-crypto.ts
@@ -1,0 +1,59 @@
+import { createCipheriv, createDecipheriv, randomBytes } from 'node:crypto';
+
+/**
+ * Symmetric encryption for third-party access tokens stored at rest.
+ *
+ * SERVER ONLY. The key lives in `LINKEDIN_TOKEN_ENC_KEY` and must never reach
+ * the browser — nothing here is `NEXT_PUBLIC_` and the module is imported solely
+ * from route handlers.
+ *
+ * AES-256-GCM: authenticated encryption, so a tampered ciphertext fails to
+ * decrypt instead of yielding garbage. Each call uses a fresh random 12-byte IV
+ * (the standard nonce size for GCM), so the same token encrypts differently
+ * every time. The persisted format is `iv:authTag:ciphertext`, all base64.
+ */
+const ALGORITHM = 'aes-256-gcm';
+const IV_BYTES = 12;
+const KEY_BYTES = 32;
+
+function readKey(): Buffer | null {
+  const raw = process.env.LINKEDIN_TOKEN_ENC_KEY;
+  if (!raw) return null;
+  const key = Buffer.from(raw, 'base64');
+  return key.length === KEY_BYTES ? key : null;
+}
+
+/** True when a valid 32-byte key is configured. */
+export function isTokenCryptoConfigured(): boolean {
+  return readKey() !== null;
+}
+
+/** Encrypts a token into `iv:authTag:ciphertext` (base64 parts). Throws if unconfigured. */
+export function encryptToken(plain: string): string {
+  const key = readKey();
+  if (!key) throw new Error('LINKEDIN_TOKEN_ENC_KEY is missing or not a 32-byte base64 key.');
+
+  const iv = randomBytes(IV_BYTES);
+  const cipher = createCipheriv(ALGORITHM, key, iv);
+  const ciphertext = Buffer.concat([cipher.update(plain, 'utf8'), cipher.final()]);
+  const authTag = cipher.getAuthTag();
+
+  return [iv.toString('base64'), authTag.toString('base64'), ciphertext.toString('base64')].join(
+    ':',
+  );
+}
+
+/** Reverses {@link encryptToken}. Throws on a malformed payload or failed auth check. */
+export function decryptToken(payload: string): string {
+  const key = readKey();
+  if (!key) throw new Error('LINKEDIN_TOKEN_ENC_KEY is missing or not a 32-byte base64 key.');
+
+  const parts = payload.split(':');
+  if (parts.length !== 3) throw new Error('Malformed encrypted token payload.');
+
+  const [iv, authTag, ciphertext] = parts.map((part) => Buffer.from(part, 'base64'));
+  const decipher = createDecipheriv(ALGORITHM, key, iv);
+  decipher.setAuthTag(authTag);
+
+  return Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString('utf8');
+}

--- a/src/shared/test-utils/prisma.mock.ts
+++ b/src/shared/test-utils/prisma.mock.ts
@@ -4,6 +4,7 @@ const mockModel = () => ({
   create: jest.fn(),
   update: jest.fn(),
   updateMany: jest.fn(),
+  upsert: jest.fn(),
   delete: jest.fn(),
   deleteMany: jest.fn(),
   count: jest.fn(),
@@ -17,6 +18,7 @@ type MockPrisma = {
   project: MockModel;
   projectImage: MockModel;
   user: MockModel;
+  linkedinConnection: MockModel;
   $transaction: jest.Mock;
 };
 
@@ -37,5 +39,6 @@ export const prisma: MockPrisma = {
   project: mockModel(),
   projectImage: mockModel(),
   user: mockModel(),
+  linkedinConnection: mockModel(),
   $transaction: mockTransaction,
 };


### PR DESCRIPTION
Closes #85\n\nAdds the LinkedIn offensive security communication playbook and launch checklist, with exact page copy, click paths, and field mapping for the Company Page launch.